### PR TITLE
recursive search of GitLabWebHookCause

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/publisher/MergeRequestNotifier.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/publisher/MergeRequestNotifier.java
@@ -7,6 +7,8 @@ import hudson.matrix.MatrixAggregatable;
 import hudson.matrix.MatrixAggregator;
 import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractBuild;
+import hudson.model.Cause;
+import hudson.model.Cause.UpstreamCause;
 import hudson.model.BuildListener;
 import hudson.model.Run;
 import hudson.model.TaskListener;


### PR DESCRIPTION
search recursively through upstream causes to find GitLabWebHookCause or return null.

With this change you can start an init your job from GitLab and e. g. notify GitLab when all downstream projects finished.
